### PR TITLE
returnIfAnyError

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -145,6 +145,16 @@
 		return null;
 	}
 	
+        function returnIfAnyError(results, callback) {
+		var err;
+		err = anyError(results);
+		if (!err) {
+			return false;
+		}
+		callback && callback(err);
+		return true;
+	};
+	
 	// export our functions
 	if (typeof exports !== "undefined") {
 		exports.define = define;
@@ -157,7 +167,8 @@
 			define: define,
 			exec: exec,
 			serialForEach: serialForEach,
-			anyError: anyError
+			anyError: anyError,
+			returnIfAnyError: returnIfAnyError
 		};
 	}
 })();


### PR DESCRIPTION
One more helper method to use like this

``` js
function your_method(data, callback)
{
  flow.exec(
    function(){ .... /*with this.MULTI() */ },
    function(results){
      if (flow.returnIfAnyError(results, callback)) return
      ... // everything's ok here
    }
  )
}
```

It looks even better with coffee

``` coffee
(data, callback) ->
  flow.exec(
    ->
      do_smth data, @MULTI()
      do_other data, @MULTI()
    (results) ->
      return if flow.returnIfAnyError results, callback
      # ...
  )
```
