### PR TITLE
Sharing data between flow blocks

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -90,6 +90,17 @@
 					timeoutCallback();
 				}, milliseconds);
 			}
+		
+      // Storage for all stashed values
+			flowState.__stash = [];
+			
+			flowState.STASH = function(key, value){
+  			flowState.__stash[key] = value;
+			}
+			
+			flowState.REVEAL = function(key){
+  			return flowState.__stash[key];
+			}
 			
 			applyArgs(flowState, this, arguments);
 		}

--- a/tests.js
+++ b/tests.js
@@ -77,19 +77,15 @@ flow.serialForEach([1, 2, 3, 4], function(val) {
 
 // STASH-REVEAL test
 flow.exec(
-	function() {
-	  this(1) //Simulates callback call
-	  
-	},function(a) {
+  function() {
+    this(1) //Simulates callback call
+  },function(a) {
     this.STASH("a", a) // We don't need 'a' here
-	  this()
-	  
-	},function() {
+    this()
+  },function() {
     this(2, 3)  // And here
-    
-	},function(b, c) {
-	  a = this.REVEAL("a") // But we need it here
+  },function(b, c) {
+    a = this.REVEAL("a") // But we need it here
     assert.strictEqual(a + b + c, 6, "invalid sum of a, b and c in parameter stash test");
-    
-	}
+  }
 );

--- a/tests.js
+++ b/tests.js
@@ -74,3 +74,22 @@ flow.serialForEach([1, 2, 3, 4], function(val) {
 	assert.deepEqual(valueSequence, [1, 3, 6, 10], "sequence of values is incorrect: " + JSON.stringify(valueSequence));
 	flowsComplete += 1;
 });
+
+// STASH-REVEAL test
+flow.exec(
+	function() {
+	  this(1) //Simulates callback call
+	  
+	},function(a) {
+    this.STASH("a", a) // We don't need 'a' here
+	  this()
+	  
+	},function() {
+    this(2, 3)  // And here
+    
+	},function(b, c) {
+	  a = this.REVEAL("a") // But we need it here
+    assert.strictEqual(a + b + c, 6, "invalid sum of a, b and c in parameter stash test");
+    
+	}
+);


### PR DESCRIPTION
There are some cases when it is necessary to pass data between the blocks of the flow.

Like there:
http://stackoverflow.com/questions/4234619/how-to-avoid-long-nesting-of-asynchronous-functions-in-node-js
or there:

```
function(){
  redisClient.smembers("names" this);
},function(err, names){
  redisClient.select(0,this);
},function(){
  redisClient.mget(/* `names` is needed here */, this);
}    
```

We have two options:
1. Keep it in the shared scope - the most obvious and the worst way, since the value could be sensetive and shouldn't be accessed out of the flow.
2. Assign it to `this.varname` - works well, but looks tricky and can cause unexpected behavior in certain circumstances.

So, I've implemented STASH and REVEAL methods for this case:

```
this.STASH("names", names)
..
names = this.REVEAL("names")
```
